### PR TITLE
fix: 連続投稿時にsnackbarを上部表示

### DIFF
--- a/lib/src/common/snackbar/view/snackbar_listener.dart
+++ b/lib/src/common/snackbar/view/snackbar_listener.dart
@@ -87,7 +87,8 @@ class SnackbarListener extends HookConsumerWidget {
                   onPressed: undo,
                   child: Text('Undo', style: TextStyle(color: undoTextColor)))
             ]
-          : [],
+          // 空だとエラーになる
+          : [const Text("")],
     );
   }
 }

--- a/lib/src/common/snackbar/view/snackbar_listener.dart
+++ b/lib/src/common/snackbar/view/snackbar_listener.dart
@@ -35,6 +35,9 @@ class SnackbarListener extends HookConsumerWidget {
             duration: const Duration(milliseconds: 2000),
             behavior: SnackBarBehavior.fixed);
 
+        scaffoldMessengerKey.currentState?.clearSnackBars();
+        scaffoldMessengerKey.currentState?.clearMaterialBanners();
+
         if (current.isFloating) {
           // snackbarが隠れる場合は上部バナーで表示
           scaffoldMessengerKey.currentState
@@ -43,7 +46,6 @@ class SnackbarListener extends HookConsumerWidget {
             scaffoldMessengerKey.currentState?.clearMaterialBanners();
           });
         } else {
-          scaffoldMessengerKey.currentState?.clearSnackBars();
           scaffoldMessengerKey.currentState?.showSnackBar(snackBar);
           ref.read(snackbarProvider.notifier).clear();
         }

--- a/lib/src/notion/tasks/task_viewmodel.dart
+++ b/lib/src/notion/tasks/task_viewmodel.dart
@@ -409,7 +409,7 @@ class TaskViewModel extends _$TaskViewModel {
     });
   }
 
-  Future<void> updateInProgressStatus(Task task,
+  Future<void> updateInProgressStatus(Task task, bool willBeInProgress,
       {bool fromUndo = false}) async {
     // checkboxは更新できない
     if (task.status is CheckboxCompleteStatusProperty) {
@@ -420,20 +420,10 @@ class TaskViewModel extends _$TaskViewModel {
       if (taskService == null) {
         return;
       }
-      final statusProperty =
-          ref.read(taskDatabaseViewModelProvider).valueOrNull?.status;
-      if (statusProperty is! StatusCompleteStatusProperty) {
-        return;
-      }
-      final inProgressOption = statusProperty.inProgressOption;
-      if (inProgressOption == null) {
-        return;
-      }
       final snackbar = ref.read(snackbarProvider.notifier);
       final locale = ref.read(settingsViewModelProvider).locale;
       final l = await AppLocalizations.delegate.load(locale);
 
-      final willBeInProgress = !task.isInProgress(inProgressOption);
       final prevState = state;
 
       snackbar.show(
@@ -441,7 +431,7 @@ class TaskViewModel extends _$TaskViewModel {
               ? l.task_update_status_in_progress(task.title)
               : l.task_update_status_todo(task.title),
           type: SnackbarType.success, onUndo: () async {
-        updateInProgressStatus(task, fromUndo: true);
+        updateInProgressStatus(task, !willBeInProgress, fromUndo: true);
       });
 
       _isLoading = true;

--- a/lib/src/notion/tasks/task_viewmodel.dart
+++ b/lib/src/notion/tasks/task_viewmodel.dart
@@ -468,49 +468,45 @@ class TaskViewModel extends _$TaskViewModel {
     if (task.isTemp) {
       return;
     }
+    final taskService = _taskService;
+    if (taskService == null) {
+      return;
+    }
 
-    await _addOperation(() async {
-      final taskService = _taskService;
-      if (taskService == null) {
-        return;
-      }
-
-      final prevState = state;
-      final snackbar = ref.read(snackbarProvider.notifier);
-      final locale = ref.read(settingsViewModelProvider).locale;
-      final l = await AppLocalizations.delegate.load(locale);
-      state = AsyncValue.data([
-        for (final t in state.valueOrNull ?? [])
-          if (t.id != task.id) t
-      ]);
-      snackbar.show(l.task_delete_success(task.title),
-          type: SnackbarType.success, onUndo: () async {
-        undoDeleteTask(task);
-      });
-
-      try {
-        await taskService.deleteTask(task.id);
-        try {
-          final analytics = ref.read(analyticsServiceProvider);
-          await analytics.logTask(
-            'task_deleted',
-            hasDueDate: task.dueDate?.start != null,
-            isCompleted: task.isCompleted,
-            fromUndo: fromUndo,
-          );
-          print('Analytics logged');
-        } catch (e) {
-          print('Analytics error: $e');
-        }
-      } catch (e) {
-        state = prevState;
-        snackbar.show(l.task_delete_failed(task.title),
-            type: SnackbarType.error);
-        // 既にNotion上で削除されている場合があるため、stateを更新する
-        // 本来はステータスコードで判定したいが、できないため
-        ref.invalidateSelf();
-      }
+    final prevState = state;
+    final snackbar = ref.read(snackbarProvider.notifier);
+    final locale = ref.read(settingsViewModelProvider).locale;
+    final l = await AppLocalizations.delegate.load(locale);
+    state = AsyncValue.data([
+      for (final t in state.valueOrNull ?? [])
+        if (t.id != task.id) t
+    ]);
+    snackbar.show(l.task_delete_success(task.title), type: SnackbarType.success,
+        onUndo: () async {
+      undoDeleteTask(task);
     });
+
+    try {
+      await taskService.deleteTask(task.id);
+      try {
+        final analytics = ref.read(analyticsServiceProvider);
+        await analytics.logTask(
+          'task_deleted',
+          hasDueDate: task.dueDate?.start != null,
+          isCompleted: task.isCompleted,
+          fromUndo: fromUndo,
+        );
+        print('Analytics logged');
+      } catch (e) {
+        print('Analytics error: $e');
+      }
+    } catch (e) {
+      state = prevState;
+      snackbar.show(l.task_delete_failed(task.title), type: SnackbarType.error);
+      // 既にNotion上で削除されている場合があるため、stateを更新する
+      // 本来はステータスコードで判定したいが、できないため
+      ref.invalidateSelf();
+    }
   }
 
   Future<void> undoDeleteTask(Task prev) async {

--- a/lib/src/notion/tasks/view/task_list_tile.dart
+++ b/lib/src/notion/tasks/view/task_list_tile.dart
@@ -5,6 +5,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../../helpers/haptic_helper.dart';
+import '../../../settings/task_database/task_database_viewmodel.dart';
+import '../../model/property.dart';
 import '../../model/task.dart';
 import '../../repository/notion_task_repository.dart';
 import '../task_viewmodel.dart';
@@ -91,8 +93,19 @@ class TaskListTile extends HookConsumerWidget {
       trailing: taskViewModel.showStarButton(task)
           ? TaskStarButton(
               task: task,
-              onInProgressChanged: (task) =>
-                  taskViewModel.updateInProgressStatus(task),
+              onInProgressChanged: (task) async {
+                final statusProperty =
+                    ref.read(taskDatabaseViewModelProvider).valueOrNull?.status;
+                if (statusProperty is! StatusCompleteStatusProperty) {
+                  return;
+                }
+                final inProgressOption = statusProperty.inProgressOption;
+                if (inProgressOption == null) {
+                  return;
+                }
+                taskViewModel.updateInProgressStatus(
+                    task, !task.isInProgress(inProgressOption));
+              },
             )
           : null,
       title: Text(task.title,

--- a/lib/src/notion/tasks/view/task_list_view.dart
+++ b/lib/src/notion/tasks/view/task_list_view.dart
@@ -22,6 +22,9 @@ class TaskListView extends HookConsumerWidget {
 
   static final DateHelper d = DateHelper();
 
+  static const double deleteThreshold = 0.4;
+  static const double editThreshold = 0.25;
+
   const TaskListView({
     super.key,
     required this.list,
@@ -72,8 +75,8 @@ class TaskListView extends HookConsumerWidget {
       key: Key(task.id),
       direction: DismissDirection.horizontal,
       dismissThresholds: const {
-        DismissDirection.endToStart: 0.4, // delete
-        DismissDirection.startToEnd: 0.25, // edit
+        DismissDirection.endToStart: deleteThreshold, // delete
+        DismissDirection.startToEnd: editThreshold, // edit
       },
       resizeDuration: null,
       onUpdate: (details) {
@@ -82,7 +85,14 @@ class TaskListView extends HookConsumerWidget {
         }
         if (details.reached) {
           reachType.value = details.direction;
-        } else if (details.progress == 0) {
+        }
+
+        if (details.progress > editThreshold &&
+            details.direction == DismissDirection.startToEnd) {
+          reachType.value = null;
+        }
+        if (details.progress < deleteThreshold &&
+            details.direction == DismissDirection.endToStart) {
           reachType.value = null;
         }
       },

--- a/lib/src/notion/tasks/view/task_list_view.dart
+++ b/lib/src/notion/tasks/view/task_list_view.dart
@@ -43,7 +43,7 @@ class TaskListView extends HookConsumerWidget {
       ThemeMode.dark =>
         MaterialTheme(Theme.of(context).textTheme).extendedColors[0].dark.color,
       ThemeMode.system =>
-        MediaQuery.of(context).platformBrightness == Brightness.light
+        MediaQuery.platformBrightnessOf(context) == Brightness.light
             ? MaterialTheme(Theme.of(context).textTheme)
                 .extendedColors[0]
                 .light


### PR DESCRIPTION
- ux: 実機でも連続投稿時のsnackbarが見えるように、上部表示に変更
- fix: undoからタスクの進行状況をもとに戻せるようにする
- ux: スワイプアクションが無効色を再度有効化
- ux: 削除時にqueueをまたずに即時実行させる
