### PR TITLE
Fix/tas 464 pagination persist

### DIFF
--- a/lib/src/notion/tasks/task_database_repository.dart
+++ b/lib/src/notion/tasks/task_database_repository.dart
@@ -27,18 +27,14 @@ class TaskDatabaseRepository {
   }
 
   /// 保存されているデータベース情報を最新の情報で更新する
-  Future<TaskDatabase?> updateDatabaseWithLatestInfo(
+  Future<TaskDatabase> updateDatabaseWithLatestInfo(
       TaskDatabase taskDatabase) async {
     try {
       final latestDatabase = await _fetchDatabase(taskDatabase.id);
       final updatedTaskDatabase =
           _updateTaskDatabaseProperties(taskDatabase, latestDatabase);
-      final isEqual = _isEqualTaskDatabase(taskDatabase, updatedTaskDatabase);
-      if (!isEqual) {
-        await save(updatedTaskDatabase);
-        return updatedTaskDatabase;
-      }
-      return null;
+      await save(updatedTaskDatabase);
+      return updatedTaskDatabase;
     } catch (e) {
       rethrow;
     }
@@ -102,34 +98,6 @@ class TaskDatabaseRepository {
     );
   }
 
-  bool _isEqualTaskDatabase(TaskDatabase a, TaskDatabase b) {
-    // statusがStatusCompleteStatusPropertyの場合、optionのnameも比較する
-    final isSameStatusOptionName = switch ((a.status, b.status)) {
-      (
-        StatusCompleteStatusProperty statusA,
-        StatusCompleteStatusProperty statusB
-      ) =>
-        statusA.todoOption?.name == statusB.todoOption?.name &&
-            statusA.inProgressOption?.name == statusB.inProgressOption?.name &&
-            statusA.completeOption?.name == statusB.completeOption?.name,
-      _ => true,
-    };
-    // priorityがある場合、optionのnameも比較する
-    final isSamePriorityOptionName = switch ((a.priority, b.priority)) {
-      (SelectProperty priorityA, SelectProperty priorityB) =>
-        priorityA.select.options.map((e) => e.name).toList() ==
-            priorityB.select.options.map((e) => e.name).toList(),
-      _ => true,
-    };
-    return a.id == b.id &&
-        a.name == b.name &&
-        a.title.name == b.title.name &&
-        a.date.name == b.date.name &&
-        a.status.name == b.status.name &&
-        isSameStatusOptionName &&
-        isSamePriorityOptionName;
-  }
-
   Future<void> save(TaskDatabase taskDatabase) async {
     // 永続化する
     final pref = await SharedPreferences.getInstance();
@@ -148,7 +116,6 @@ class TaskDatabaseRepository {
     }
     final databases = data.map<Database>((e) => _getDatabase(e)).toList();
 
-    // print('databases: $databases');
     return databases;
   }
 

--- a/lib/src/notion/tasks/task_viewmodel.dart
+++ b/lib/src/notion/tasks/task_viewmodel.dart
@@ -22,7 +22,7 @@ import '../../common/debounced_state_mixin.dart';
 
 part 'task_viewmodel.g.dart';
 
-@riverpod
+@Riverpod(keepAlive: true)
 class TaskViewModel extends _$TaskViewModel
     with DebouncedStateMixin<List<Task>> {
   late TaskRepository? _taskRepository;

--- a/lib/src/notion/tasks/task_viewmodel.dart
+++ b/lib/src/notion/tasks/task_viewmodel.dart
@@ -14,7 +14,6 @@ import '../../settings/task_database/task_database_viewmodel.dart';
 import '../common/filter_type.dart';
 import '../model/property.dart';
 import '../model/task.dart';
-import '../model/task_database.dart';
 import 'task_repository.dart';
 import '../../common/analytics/analytics_service.dart';
 import '../../common/app_review/app_review_service.dart';
@@ -44,11 +43,7 @@ class TaskViewModel extends _$TaskViewModel
   Future<List<Task>> build({
     FilterType filterType = FilterType.all,
   }) async {
-    // 最新のDB情報を事前に取得。ref.refreshするとstateが破棄されるので使わない
-    final taskDatabaseViewModel =
-        ref.read(taskDatabaseViewModelProvider.notifier);
-    TaskDatabase? taskDatabase = await taskDatabaseViewModel.refresh();
-
+    final taskDatabase = await ref.watch(taskDatabaseViewModelProvider.future);
     _taskRepository = await ref.watch(taskRepositoryProvider.future);
 
     if (_taskRepository == null || taskDatabase == null) {

--- a/lib/src/notion/tasks/task_viewmodel.g.dart
+++ b/lib/src/notion/tasks/task_viewmodel.g.dart
@@ -6,7 +6,7 @@ part of 'task_viewmodel.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$taskViewModelHash() => r'19e017b85f71bd49815af79453e2d6649089bbee';
+String _$taskViewModelHash() => r'7463b127c6f65eaa4e2841b33e23c5af2c8b6b53';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -29,8 +29,7 @@ class _SystemHash {
   }
 }
 
-abstract class _$TaskViewModel
-    extends BuildlessAutoDisposeAsyncNotifier<List<Task>> {
+abstract class _$TaskViewModel extends BuildlessAsyncNotifier<List<Task>> {
   late final FilterType filterType;
 
   FutureOr<List<Task>> build({
@@ -82,7 +81,7 @@ class TaskViewModelFamily extends Family<AsyncValue<List<Task>>> {
 
 /// See also [TaskViewModel].
 class TaskViewModelProvider
-    extends AutoDisposeAsyncNotifierProviderImpl<TaskViewModel, List<Task>> {
+    extends AsyncNotifierProviderImpl<TaskViewModel, List<Task>> {
   /// See also [TaskViewModel].
   TaskViewModelProvider({
     FilterType filterType = FilterType.all,
@@ -138,8 +137,7 @@ class TaskViewModelProvider
   }
 
   @override
-  AutoDisposeAsyncNotifierProviderElement<TaskViewModel, List<Task>>
-      createElement() {
+  AsyncNotifierProviderElement<TaskViewModel, List<Task>> createElement() {
     return _TaskViewModelProviderElement(this);
   }
 
@@ -159,13 +157,13 @@ class TaskViewModelProvider
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-mixin TaskViewModelRef on AutoDisposeAsyncNotifierProviderRef<List<Task>> {
+mixin TaskViewModelRef on AsyncNotifierProviderRef<List<Task>> {
   /// The parameter `filterType` of this provider.
   FilterType get filterType;
 }
 
 class _TaskViewModelProviderElement
-    extends AutoDisposeAsyncNotifierProviderElement<TaskViewModel, List<Task>>
+    extends AsyncNotifierProviderElement<TaskViewModel, List<Task>>
     with TaskViewModelRef {
   _TaskViewModelProviderElement(super.provider);
 

--- a/lib/src/notion/tasks/task_viewmodel.g.dart
+++ b/lib/src/notion/tasks/task_viewmodel.g.dart
@@ -6,7 +6,7 @@ part of 'task_viewmodel.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$taskViewModelHash() => r'7463b127c6f65eaa4e2841b33e23c5af2c8b6b53';
+String _$taskViewModelHash() => r'2ecdb47150557a66c1d387f3ef8ae1167a94131b';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/src/notion/tasks/view/task_main_page.dart
+++ b/lib/src/notion/tasks/view/task_main_page.dart
@@ -140,6 +140,7 @@ class TaskMainPage extends HookConsumerWidget {
                   // Today Tasks
                   TaskRefreshIndicator(
                     onRefresh: () async {
+                      ref.invalidate(taskDatabaseViewModelProvider);
                       ref.invalidate(todayProvider);
                     },
                     child: todayTasks.when(
@@ -161,6 +162,7 @@ class TaskMainPage extends HookConsumerWidget {
                   // All Tasks
                   TaskRefreshIndicator(
                     onRefresh: () async {
+                      ref.invalidate(taskDatabaseViewModelProvider);
                       ref.invalidate(allProvider);
                     },
                     child: allTasks.when(

--- a/lib/src/settings/task_database/task_database_viewmodel.dart
+++ b/lib/src/settings/task_database/task_database_viewmodel.dart
@@ -26,11 +26,11 @@ class TaskDatabaseViewModel extends _$TaskDatabaseViewModel
     final taskDatabase = await _taskDatabaseRepository!.loadSetting();
     if (taskDatabase == null) return null;
     try {
-      final updatedTaskDatabase = await debouncedFetch(() async {
+      final latestTaskDatabase = await debouncedFetch(() async {
         return await _taskDatabaseRepository!
             .updateDatabaseWithLatestInfo(taskDatabase);
       });
-      return updatedTaskDatabase ?? taskDatabase;
+      return latestTaskDatabase;
     } catch (e) {
       return taskDatabase;
     }

--- a/lib/src/settings/task_database/task_database_viewmodel.dart
+++ b/lib/src/settings/task_database/task_database_viewmodel.dart
@@ -22,13 +22,6 @@ class TaskDatabaseViewModel extends _$TaskDatabaseViewModel
     return await _getLatestTaskDatabase();
   }
 
-  Future<TaskDatabase?> refresh() async {
-    final latestTaskDatabase = await _getLatestTaskDatabase();
-    state = AsyncValue.data(latestTaskDatabase);
-
-    return latestTaskDatabase;
-  }
-
   Future<TaskDatabase?> _getLatestTaskDatabase() async {
     if (_taskDatabaseRepository == null) {
       return null;

--- a/lib/src/settings/task_database/task_database_viewmodel.dart
+++ b/lib/src/settings/task_database/task_database_viewmodel.dart
@@ -19,10 +19,20 @@ class TaskDatabaseViewModel extends _$TaskDatabaseViewModel
     _taskDatabaseRepository =
         await ref.watch(taskDatabaseRepositoryProvider.future);
 
+    return await _getLatestTaskDatabase();
+  }
+
+  Future<TaskDatabase?> refresh() async {
+    final latestTaskDatabase = await _getLatestTaskDatabase();
+    state = AsyncValue.data(latestTaskDatabase);
+
+    return latestTaskDatabase;
+  }
+
+  Future<TaskDatabase?> _getLatestTaskDatabase() async {
     if (_taskDatabaseRepository == null) {
       return null;
     }
-
     final taskDatabase = await _taskDatabaseRepository!.loadSetting();
     if (taskDatabase == null) return null;
     try {

--- a/lib/src/settings/task_database/task_database_viewmodel.g.dart
+++ b/lib/src/settings/task_database/task_database_viewmodel.g.dart
@@ -7,7 +7,7 @@ part of 'task_database_viewmodel.dart';
 // **************************************************************************
 
 String _$taskDatabaseViewModelHash() =>
-    r'6b42005eb495d7fe3df074185dbfc48faca3906c';
+    r'd58c20d31c5fa7edbdc44b5e61931f92e342f9c6';
 
 /// See also [TaskDatabaseViewModel].
 @ProviderFor(TaskDatabaseViewModel)

--- a/lib/src/settings/task_database/task_database_viewmodel.g.dart
+++ b/lib/src/settings/task_database/task_database_viewmodel.g.dart
@@ -7,7 +7,7 @@ part of 'task_database_viewmodel.dart';
 // **************************************************************************
 
 String _$taskDatabaseViewModelHash() =>
-    r'd58c20d31c5fa7edbdc44b5e61931f92e342f9c6';
+    r'125ef5b0b3b2987e2bdf083367009921368f6fd1';
 
 /// See also [TaskDatabaseViewModel].
 @ProviderFor(TaskDatabaseViewModel)


### PR DESCRIPTION
一覧更新のためにDBも更新するとロード時間が長くなるため、DB更新はアプリ起動時&pullするときに限定する

- Statusのオプション名を変えても挙動に問題なし