### PR TITLE
fix: 完了音がバックグラウンド音楽を中断しないように修正

### DIFF
--- a/lib/src/common/sound/sound_service.dart
+++ b/lib/src/common/sound/sound_service.dart
@@ -2,6 +2,7 @@ import 'package:audioplayers/audioplayers.dart';
 
 class SoundService {
   final AudioPlayer _audioPlayer = AudioPlayer();
+  final AudioPlayer _completionSoundPlayer = AudioPlayer();
 
   Future<void> playSound(String assetPath) async {
     try {
@@ -11,11 +12,20 @@ class SoundService {
     }
   }
 
+  Future<void> playCompletionSound(String assetPath) async {
+    try {
+      await _completionSoundPlayer.play(AssetSource(assetPath));
+    } catch (e) {
+      print('Error playing completion sound: $e');
+    }
+  }
+
   Future<void> stopSound() async {
     await _audioPlayer.stop();
   }
 
   void dispose() {
     _audioPlayer.dispose();
+    _completionSoundPlayer.dispose();
   }
 }

--- a/lib/src/common/sound/sound_viewmodel.dart
+++ b/lib/src/common/sound/sound_viewmodel.dart
@@ -28,8 +28,7 @@ class SoundViewModel {
 
   Future<void> playSound() async {
     if (!_soundEnabled) return;
-    await _soundService.stopSound();
-    await _soundService.playSound(soundPath);
+    await _soundService.playCompletionSound(soundPath);
   }
 
   void dispose() {

--- a/test/src/common/sound/sound_service_test.dart
+++ b/test/src/common/sound/sound_service_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:notion_todo/src/common/sound/sound_service.dart';
+
+void main() {
+  group('SoundService', () {
+    late SoundService soundService;
+
+    setUp(() {
+      soundService = SoundService();
+    });
+
+    tearDown(() {
+      soundService.dispose();
+    });
+
+    test('playCompletionSound should not stop other sounds', () async {
+      // playSound で音声を再生
+      await soundService.playSound('sounds/test.mp3');
+      
+      // playCompletionSound を呼び出しても他の音声に影響しない
+      await soundService.playCompletionSound('sounds/complete.mp3');
+      
+      // この時点で両方のAudioPlayerが独立して動作していることを確認
+      // AudioPlayerはモックなしでは実際の再生状態を確認できないため、
+      // エラーが発生しないことを確認
+      expect(() async => await soundService.stopSound(), returnsNormally);
+    });
+
+    test('dispose should dispose both audio players', () {
+      // disposeがエラーなく実行されることを確認
+      expect(() => soundService.dispose(), returnsNormally);
+    });
+  });
+}

--- a/test/src/common/sound/sound_viewmodel_test.dart
+++ b/test/src/common/sound/sound_viewmodel_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:notion_todo/src/common/sound/sound_service.dart';
+import 'package:notion_todo/src/common/sound/sound_viewmodel.dart';
+
+void main() {
+  group('SoundViewModel', () {
+    test('playSound should use playCompletionSound when enabled', () async {
+      final soundService = _MockSoundService();
+      final viewModel = SoundViewModel(soundService, true);
+      
+      await viewModel.playSound();
+      
+      expect(soundService.playCompletionSoundCalled, true);
+      expect(soundService.playSoundCalled, false);
+    });
+
+    test('playSound should not play when disabled', () async {
+      final soundService = _MockSoundService();
+      final viewModel = SoundViewModel(soundService, false);
+      
+      await viewModel.playSound();
+      
+      expect(soundService.playCompletionSoundCalled, false);
+      expect(soundService.playSoundCalled, false);
+    });
+  });
+}
+
+class _MockSoundService extends SoundService {
+  bool playCompletionSoundCalled = false;
+  bool playSoundCalled = false;
+
+  @override
+  Future<void> playCompletionSound(String assetPath) async {
+    playCompletionSoundCalled = true;
+  }
+
+  @override
+  Future<void> playSound(String assetPath) async {
+    playSoundCalled = true;
+  }
+
+  @override
+  void dispose() {}
+}


### PR DESCRIPTION
Fixes #106

## 変更内容
- 完了音専用のAudioPlayerインスタンスを追加
- playCompletionSoundメソッドを新規作成
- SoundViewModelでstopSound()の呼び出しを削除
- テストを追加

🤖 Generated with [Claude Code](https://claude.ai/code)