### PR TITLE
fix: 画像表示修正

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,8 @@ flutter:
   generate: true
   assets:
     - assets/images/
+    - assets/images/app_icon/
+    - assets/images/splash/
     - assets/google_fonts/
     - assets/sounds/
 


### PR DESCRIPTION
## 概要
タスク一覧で画像がピンク枠になる問題を修正しました。

## 変更内容
- pubspec.yamlのassets設定にサブディレクトリを明示的に追加
  - `assets/images/app_icon/`
  - `assets/images/splash/`

## 参照
- Fixes #115

Generated with [Claude Code](https://claude.ai/code)